### PR TITLE
Handle jp2 entries in icns files.

### DIFF
--- a/createicns.c
+++ b/createicns.c
@@ -63,16 +63,27 @@ struct {
   const char* icon_filename;
   uint32_t icon_type;
 } static const kIconTypes[] = {
+    {"icon_16x16.jp2", 'icp4'},
     {"icon_16x16.png", 'icp4'},
+    {"icon_16x16@2x.jp2", 'ic11'},
     {"icon_16x16@2x.png", 'ic11'},
+    {"icon_32x32.jp2", 'icp5'},
     {"icon_32x32.png", 'icp5'},
+    {"icon_32x32@2x.jp2", 'ic12'},
     {"icon_32x32@2x.png", 'ic12'},
+    {"icon_64x64.jp2", 'icp6'},
     {"icon_64x64.png", 'icp6'},
+    {"icon_128x128.jp2", 'ic07'},
     {"icon_128x128.png", 'ic07'},
+    {"icon_128x128@2x.jp2", 'ic13'},
     {"icon_128x128@2x.png", 'ic13'},
+    {"icon_256x256.jp2", 'ic08'},
     {"icon_256x256.png", 'ic08'},
+    {"icon_256x256@2x.jp2", 'ic14'},
     {"icon_256x256@2x.png", 'ic14'},
+    {"icon_512x512.jp2", 'ic09'},
     {"icon_512x512.png", 'ic09'},
+    {"icon_512x512@2x.jp2", 'ic10'},
     {"icon_512x512@2x.png", 'ic10'}
 };
 

--- a/readicns.c
+++ b/readicns.c
@@ -52,6 +52,10 @@ static const char kIcnsExtension[] = ".icns";
 static const char kUnknownFormatFilename[] = "icon_data_";
 static const uint32_t kMagicHeader = 'icns';
 
+static uint8_t kJp2Magic[] = {
+  0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50, 0x20, 0x20, 0x0D, 0x0A, 0x87, 0x0A
+};
+
 typedef struct {
   char path[MAXPATHLEN];
 } Path;
@@ -218,6 +222,8 @@ bool CopyIconToIconset(FILE* icns, Path iconset_path) {
     return false;
   }
 
+  int is_jp2 = -1;
+
   uint8_t buffer[kBufferSize];
   while (size > 0) {
     size_t to_read = size > kBufferSize ? kBufferSize : size;
@@ -227,10 +233,18 @@ bool CopyIconToIconset(FILE* icns, Path iconset_path) {
       fclose(target);
       return false;
     }
+    if (is_jp2 == -1) {
+      is_jp2 = !memcmp(buffer, kJp2Magic, sizeof(kJp2Magic));
+    }
     size -= to_read;
   }
 
   fclose(target);
+  if (is_jp2) {
+    Path orig_path = iconset_path;
+    strcpy(iconset_path.path + strlen(iconset_path.path) - 3, "jp2");
+    rename(orig_path.path, iconset_path.path);
+  }
   return true;
 }
 


### PR DESCRIPTION
Some icns files may have jp2 encoded images. These are stored
the same way as PNGs but with different file content. Handle
these correctly - in both reading and creating.